### PR TITLE
RTTI Quickfix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@ data_dir = data.gz
 
 [env:firebeetle2]
 monitor_speed = 115200
-platform = espressif32@^5.2.0
+platform = espressif32@5.2.0
 board = firebeetle2
 board_build.partitions = no_ota.csv
 framework = arduino


### PR DESCRIPTION
The latest espressif32 platform update (5.3.0) breaks RTTI. Now set to 5.2.0 until I can fix.